### PR TITLE
Crash Error instances without processing them

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruins-ts",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "",
   "main": "lib/ruins.js",
   "files": [

--- a/src/helpers/__tests__/crash.ts
+++ b/src/helpers/__tests__/crash.ts
@@ -3,12 +3,16 @@ import { crash, crashMessage, crashObject } from '../crash';
 describe('crash library', () => {
   const exampleJSON: unknown = { foo: 123 };
   const exampleCyclic: unknown = {};
+  const exampleError: Error = new Error('Boom!');
+
   // eslint-disable-next-line
   (exampleCyclic as any).foo = exampleCyclic;
 
   const exampleCrashMessage = crashMessage(exampleJSON);
-  const exampleCrashObject = crashObject(exampleJSON);
-  const exampleCrash = crash(exampleJSON);
+  const exampleCrashObject1 = crashObject(exampleJSON);
+  const exampleCrashObject2 = crashObject(exampleError);
+  const exampleCrash1 = crash(exampleJSON);
+  const exampleCrash2 = crash(exampleError);
 
   describe('crashMessage', () => {
     it('should return input as JSON if possible', () => {
@@ -21,13 +25,19 @@ describe('crash library', () => {
 
   describe('crashObject', () => {
     it('should return an error object', () => {
-      expect(exampleCrashObject).toEqual(new Error(crashMessage(exampleJSON)));
+      expect(exampleCrashObject1).toEqual(new Error(crashMessage(exampleJSON)));
+    });
+    it('should return an error object unchanged', () => {
+      expect(exampleCrashObject2).toEqual(exampleError);
     });
   });
 
   describe('crash', () => {
     it('should crash', () => {
-      expect(exampleCrash).toThrowError(exampleCrashObject);
+      expect(exampleCrash1).toThrowError(exampleCrashObject1);
+    });
+    it('should crash', () => {
+      expect(exampleCrash2).toThrowError(exampleCrashObject2);
     });
   });
 });

--- a/src/helpers/crash.ts
+++ b/src/helpers/crash.ts
@@ -8,7 +8,11 @@ export const crashMessage = (originalError: unknown): string =>
     Json_.stringify(originalError),
     Either_.getOrElse(() => String(originalError)),
   );
+
 export const crashObject = (error: unknown): Error => {
+  if (error instanceof Error) {
+    return error;
+  }
   const errorMessage = crashMessage(error);
   return new Error(errorMessage);
 };


### PR DESCRIPTION
This PR allows instances of errors to pass-through the crash helper untouched.
This removes a layer of processing when the error case is already an Error instance.

Additionally, some fixes were made to incorrect async usage of jest resolves/rejects statements.
E.g.
```
it('should work', () => {
    expect(ruins.fromTaskOption(...)).resolves.toBe(...);
}
```

Changed to:
```
it('should work', async () => {
    await expect(ruins.fromTaskOption(...)).resolves.toBe(...);
}
```

This uncovered a broken test for task-option, which was also fixed.
