### PR TITLE
Async tests fix

### DIFF
--- a/src/modules/__tests__/task-either.ts
+++ b/src/modules/__tests__/task-either.ts
@@ -15,12 +15,12 @@ const exampleTaskEitherL: ExampleTaskEither = TaskEither_.left(exampleLeft);
 const exampleTaskEitherR: ExampleTaskEither = TaskEither_.right(exampleRight);
 
 describe('ruinTaskEither', () => {
-  it('should return right', () => {
-    expect(ruins.fromTaskEither(exampleTaskEitherR)).resolves.toEqual(exampleRight);
+  it('should return right', async () => {
+    await expect(ruins.fromTaskEither(exampleTaskEitherR)).resolves.toEqual(exampleRight);
   });
 
-  it('should throw left', () => {
-    expect(ruins.fromTaskEither(exampleTaskEitherL)).rejects.toEqual(
+  it('should throw left', async () => {
+    await expect(ruins.fromTaskEither(exampleTaskEitherL)).rejects.toEqual(
       crashObject(exampleLeft),
     );
   });

--- a/src/modules/__tests__/task-option.ts
+++ b/src/modules/__tests__/task-option.ts
@@ -16,6 +16,6 @@ describe('ruinTaskOption', () => {
   });
 
   it('should convert none to null', async () => {
-    await expect(ruins.fromTaskOption(exampleTaskOptionN)).rejects.toEqual(null);
+    await expect(ruins.fromTaskOption(exampleTaskOptionN)).resolves.toEqual(null);
   });
 });

--- a/src/modules/__tests__/task-option.ts
+++ b/src/modules/__tests__/task-option.ts
@@ -11,11 +11,11 @@ const exampleTaskOptionN: ExampleTaskOption = TaskOption_.none;
 const exampleTaskOptionS: ExampleTaskOption = TaskOption_.some(example);
 
 describe('ruinTaskOption', () => {
-  it('should return value of some', () => {
-    expect(ruins.fromTaskOption(exampleTaskOptionS)).resolves.toEqual(example);
+  it('should return value of some', async () => {
+    await expect(ruins.fromTaskOption(exampleTaskOptionS)).resolves.toEqual(example);
   });
 
-  it('should convert none to null', () => {
-    expect(ruins.fromTaskOption(exampleTaskOptionN)).rejects.toEqual(null);
+  it('should convert none to null', async () => {
+    await expect(ruins.fromTaskOption(exampleTaskOptionN)).rejects.toEqual(null);
   });
 });

--- a/src/modules/__tests__/task-these.ts
+++ b/src/modules/__tests__/task-these.ts
@@ -16,12 +16,12 @@ const exampleTaskTheseR: ExampleTaskThese = TaskThese_.right(exampleRight);
 const exampleTaskTheseB: ExampleTaskThese = TaskThese_.both(exampleLeft, exampleRight);
 
 describe('ruinTaskThese', () => {
-  it('should return right', () => {
-    expect(ruins.fromTaskThese(exampleTaskTheseR)).resolves.toEqual(exampleRight);
+  it('should return right', async () => {
+    await expect(ruins.fromTaskThese(exampleTaskTheseR)).resolves.toEqual(exampleRight);
   });
 
-  it('should throw left', () => {
-    expect(ruins.fromTaskThese(exampleTaskTheseL)).rejects.toEqual(
+  it('should throw left', async () => {
+    await expect(ruins.fromTaskThese(exampleTaskTheseL)).rejects.toEqual(
       crashObject(exampleLeft),
     );
   });

--- a/src/modules/__tests__/task.ts
+++ b/src/modules/__tests__/task.ts
@@ -16,11 +16,11 @@ const exampleTask: Task<Answer> = async () => {
 };
 
 describe('ruinTask', () => {
-  it('should execute side effects', () => {
-    expect(ruins.fromTask(exampleTask).then(() => mutableState)).resolves.toEqual(true);
+  it('should execute side effects', async () => {
+    await expect(ruins.fromTask(exampleTask).then(() => mutableState)).resolves.toEqual(true);
   });
 
-  it('should return computation return value', () => {
-    expect(ruins.fromTask(exampleTask)).resolves.toEqual(answer);
+  it('should return computation return value', async () => {
+    await expect(ruins.fromTask(exampleTask)).resolves.toEqual(answer);
   });
 });


### PR DESCRIPTION
Some fixes were made to incorrect async usage of jest resolves/rejects statements.
E.g.
```
it('should work', () => {
    expect(ruins.fromTaskOption(...)).resolves.toBe(...);
}
```

Changed to:
```
it('should work', async () => {
    await expect(ruins.fromTaskOption(...)).resolves.toBe(...);
}
```

This uncovered a broken test for task-option, which was also fixed.
