### PR TITLE
Add fromReaderEither and fromReaderTaskEither

### DIFF
--- a/src/modules/__tests__/reader-either.ts
+++ b/src/modules/__tests__/reader-either.ts
@@ -1,0 +1,32 @@
+import { Either } from 'fp-ts/lib/Either';
+import * as Either_ from 'fp-ts/lib/Either';
+
+import { crashObject } from '../../helpers/crash';
+import * as ruins from '../reader-either';
+
+const exampleModel = { foo: 'model' };
+
+type ExampleLeft = { error: number };
+const exampleLeft: ExampleLeft = { error: 404 };
+
+type ExampleRight = { result: number };
+const exampleRight: ExampleRight = { result: 42 };
+
+type ExampleEither = Either<ExampleLeft, ExampleRight>;
+const exampleEitherL: ExampleEither = Either_.left(exampleLeft);
+const exampleEitherR: ExampleEither = Either_.right(exampleRight);
+
+describe('ruinReaderEither', () => {
+  it('should return right', () => {
+    const result: ExampleRight = ruins.fromReaderEither(
+      exampleModel,
+      (_) => exampleEitherR,
+    );
+    expect(result).toEqual(exampleRight);
+  });
+  it('should throw left', () => {
+    expect(() =>
+      ruins.fromReaderEither(exampleModel, (_) => exampleEitherL),
+    ).toThrowError(crashObject(exampleLeft));
+  });
+});

--- a/src/modules/__tests__/reader-task-either.ts
+++ b/src/modules/__tests__/reader-task-either.ts
@@ -1,0 +1,31 @@
+import { TaskEither } from 'fp-ts/lib/TaskEither';
+import * as TaskEither_ from 'fp-ts/lib/TaskEither';
+
+import { crashObject } from '../../helpers/crash';
+import * as ruins from '../reader-task-either';
+
+const exampleModel = { foo: 'model' };
+
+type ExampleLeft = { error: number };
+const exampleLeft: ExampleLeft = { error: 404 };
+
+type ExampleRight = { result: number };
+const exampleRight: ExampleRight = { result: 42 };
+
+type ExampleTaskEither = TaskEither<ExampleLeft, ExampleRight>;
+const exampleTaskEitherL: ExampleTaskEither = TaskEither_.left(exampleLeft);
+const exampleTaskEitherR: ExampleTaskEither = TaskEither_.right(exampleRight);
+
+describe('ruinReaderTaskEither', () => {
+  it('should return right', async () => {
+    await expect(
+      ruins.fromReaderTaskEither(exampleModel, (_) => exampleTaskEitherR),
+    ).resolves.toEqual(exampleRight);
+  });
+
+  it('should throw left', async () => {
+    await expect(
+      ruins.fromReaderTaskEither(exampleModel, (_) => exampleTaskEitherL),
+    ).rejects.toEqual(crashObject(exampleLeft));
+  });
+});

--- a/src/modules/__tests__/task.ts
+++ b/src/modules/__tests__/task.ts
@@ -17,7 +17,9 @@ const exampleTask: Task<Answer> = async () => {
 
 describe('ruinTask', () => {
   it('should execute side effects', async () => {
-    await expect(ruins.fromTask(exampleTask).then(() => mutableState)).resolves.toEqual(true);
+    await expect(ruins.fromTask(exampleTask).then(() => mutableState)).resolves.toEqual(
+      true,
+    );
   });
 
   it('should return computation return value', async () => {

--- a/src/modules/reader-either.ts
+++ b/src/modules/reader-either.ts
@@ -1,0 +1,9 @@
+import { pipe } from 'fp-ts/lib/function';
+import { ReaderEither } from 'fp-ts/ReaderEither';
+
+import { fromEither } from './either';
+
+export const fromReaderEither = <M, R>(
+  model: M,
+  aReaderEither: ReaderEither<M, unknown, R>,
+): R => pipe(model, aReaderEither, fromEither);

--- a/src/modules/reader-task-either.ts
+++ b/src/modules/reader-task-either.ts
@@ -1,0 +1,9 @@
+import { pipe } from 'fp-ts/lib/function';
+import { ReaderTaskEither } from 'fp-ts/ReaderTaskEither';
+
+import { fromTaskEither } from './task-either';
+
+export const fromReaderTaskEither = <M, E, R>(
+  model: M,
+  aReaderTaskEither: ReaderTaskEither<M, E, R>,
+): Promise<R> => pipe(model, aReaderTaskEither, fromTaskEither);


### PR DESCRIPTION
The use-case is for jest tests.
E.g.
```
      await P.pipe(
        model,
        someReaderTaskEither(),
        P.Task_.map(
          P.Either_.fold(fail, (result) => {
            expect(stub1.calls().length).toBe(1);
            expect(result).toStrictEqual({ Contents: [{ Key: 'bar/test-file.txt' }] });
          })
        ),
        (invoke) => invoke()
      );
```
Or possibly:
```
      const result = await P.pipe(
        model,
        unit.s3ListObjects({
          Type: FileType.Directory,
          Bucket: 'foobucket',
          Path: 'bar/' as DirectoryPath,
          FullPath: 'bar/',
        }),
        fromTaskEither
      );
      expect(stub1.calls().length).toBe(1);
      expect(result).toStrictEqual({ Contents: [{ Key: 'bar/test-file.txt' }] });

```

can become:
```
      const result = await fromReaderTaskEither(model, someReaderTaskEither());

      expect(stub1.calls().length).toBe(1);
      expect(result).toStrictEqual({ Contents: [{ Key: 'bar/test-file.txt' }] });
```

Although, maybe it's better to look at this:
https://github.com/relmify/jest-fp-ts


NOTE: if this is accepted, need to add new functions to README